### PR TITLE
optimised the byte order reversal code

### DIFF
--- a/lz4_frame.asm
+++ b/lz4_frame.asm
@@ -27,12 +27,12 @@ lz4_frame_depack:
 		bne.s	lz4_frame_error
 
 		; read 32bits block size without movep (little endian)
+		move.b	4(a0),d0
+		swap	d0
 		move.b	6(a0),d0
-		lsl.w	#8,d0
+		lsl.l	#8,d0
 		move.b	5(a0),d0
 		swap	d0
-		move.b	4(a0),d0
-		lsl.w	#8,d0
 		move.b	3(a0),d0
 		lea		7(a0),a0			; skip LZ4 block header + packed data size
 


### PR DESCRIPTION
replaced two short shifts and one swap against one long shift and two swaps which is 16 cycles faster on 68000